### PR TITLE
feat: improve runtime-diagnoser skill

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -204,9 +204,14 @@ deploy-orchestrator  (subagent — LLM 이 여기 살아있음)
   │         └── helm template 파싱, kubectl_wait_staged, smoke_test
   │
   │  runtime fail 시:
-  ├─►  Task(subagent_type="runtime-diagnoser", prompt=<요약 + 로그 경로>)
-  │         └── diagnoser 가 Read 로 세션 로그를 열람, kagent 쿼리,
-  │             observations + proposed_files 를 JSON 으로 반환
+  ├─►  Task(subagent_type="runtime-diagnoser",
+  │         prompt=<service/phase + verify_runtime_response (log_tail 포함) + 로그 경로>)
+  │         └── prompt 의 log_tail 로 가설 수립 (Step 0) →
+  │             Branch A (non-smoke): 가설 1개 → 반증용 kagent 쿼리, 최대 3 cycle,
+  │             Branch B (smoke_test): smoke 소스 1 Read + readiness 1 쿼리,
+  │                                    proposed_files=[] 고정,
+  │             Fallback: log_tail 비semantic 시 events→describe→logs sweep →
+  │             observations + proposed_files + suggestions 를 JSON 으로 반환
   │
   │  proposed_files 가 비어있지 않으면:
   ├─►  각각에 대해 Write(...) — `allow` 권한으로 중단 없이 진행
@@ -294,7 +299,7 @@ deploy-orchestrator  (subagent — LLM 이 여기 살아있음)
   --- [TOOL/Edit] 13:14:25 | ok | {workspace}/helm/emqx/values.yaml | lines_changed=3->5 ---
   --- [TOOL/Task] 14:32:05 | ok | subagent=runtime-diagnoser | emqx cluster fail ---
   <<< subagent response >>>
-  {"service":"emqx","failed_stage":"verify-runtime","root_cause":"..."}
+  {"service":"emqx","failure_source":"implementation","observations":["..."],"proposed_files":[{"path":"...","content":"..."}],"suggestions":[]}
   <<< end >>>
   ```
   Task 호출은 예외적으로 subagent 응답 본문을 함께 덤프함 (4000자 cap). diagnoser 결과가 orchestrator Task 반환값으로만 흐르고 세션 로그에 남지 않는 갭을 막기 위함. 훅은 `.harness/current-session-log` 포인터로 활성 로그를 찾음. LLM 은 이 줄을 읽지 않음 — 훅이 Claude Code 런타임에서 실행돼 토큰 비용 0.

--- a/harness/templates/.claude/agents/runtime-diagnoser.md.tmpl
+++ b/harness/templates/.claude/agents/runtime-diagnoser.md.tmpl
@@ -53,30 +53,36 @@ Optional:
 
 ## Workflow
 
-1. If `session_log` is set, `Read` the tail of that file to find the
-   first failing check and its `log_tail`.
-2. **Load domain knowledge.** If the Task prompt carries a `phase` /
-   `service` (or `service_spec`), `Read context/phases/<phase>.md`,
-   find the service's `**references**:` field, and `Read` every
-   `context/knowledge/*.md` path it lists. Scan the service's
-   narrative bullets too — port roles, retention, resource sizing
-   often name the exact constraint that's being violated. See the
-   `runtime-diagnosis` skill's "Domain knowledge before web search"
-   section for precedence rules.
-3. Classify the failure into `failure_source`:
+1. **Read the failure signal that's already in your prompt.**
+   `verify_runtime_response.checks[*]` carries each failed check's
+   `log_tail` (up to 2000 chars of combined stdout/stderr). That
+   payload is your starting point — do **not** `Read` `session_log`
+   first; the tail is already there. Only escalate to a fuller
+   session log read when 2000 chars truncated mid-message.
+2. **Load domain knowledge** if the failure references
+   technology-specific behavior. If the Task prompt carries a
+   `phase` / `service` (or `service_spec`), `Read
+   context/phases/<phase>.md`, find the service's `**references**:`
+   field, and `Read` every `context/knowledge/*.md` path it lists.
+   Scan the service's narrative bullets too — port roles, retention,
+   resource sizing often name the exact constraint being violated.
+   See the `runtime-diagnosis` skill's "Domain knowledge before web
+   search" section for precedence rules.
+3. **Follow the SKILL's branched investigation.** Branch A (non-
+   smoke, hypothesis-first from log_tail), Branch B (smoke_test,
+   bounded smoke source read + one readiness query), or Fallback
+   sweep when log_tail is non-semantic. The SKILL is authoritative
+   for tool order; do **not** run a full
+   events → describe → logs → connectivity sweep by default.
+4. **Classify** into `failure_source`:
    - `implementation` — chart values, Dockerfile, or image content
      wrong. Fixable with a file edit.
-   - `smoke_test` — the deployment is healthy but the smoke test
-     script rejects it. Needs human review of the test.
-   - `environment` — cluster or dependency issue outside the service
-     (missing namespace quota, broken DNS, missing secret). Not
-     fixable inside the service's chart.
-4. Gather evidence via kagent:
-   - `k8s_get_events -n <namespace>` for recent warnings.
-   - `k8s_describe_resource` on the deployment/statefulset.
-   - `k8s_get_pod_logs` for any pod in a terminal state.
-   - `k8s_check_service_connectivity` if a smoke test failed on a
-     network call.
+   - `smoke_test` — pods are `Ready` but the smoke test script
+     rejects the deployment. Needs human review of the test or the
+     service. `proposed_files` MUST be empty in this case.
+   - `environment` — cluster or dependency issue outside the
+     service (missing namespace quota, broken DNS, missing secret).
+     Not fixable inside the service's chart.
 5. If the root cause suggests a file edit (typically chart values or
    Dockerfile), draft the minimal change. Use `Read` to load the
    existing file first; never invent content.

--- a/harness/templates/.claude/skills/runtime-diagnosis/SKILL.md.tmpl
+++ b/harness/templates/.claude/skills/runtime-diagnosis/SKILL.md.tmpl
@@ -1,6 +1,6 @@
 ---
 name: runtime-diagnosis
-description: Investigation pattern for a runtime deployment failure — event → describe → logs → connectivity, with failure-source classification. Loaded by the runtime-diagnoser subagent; do not invoke from the main session.
+description: Investigation pattern for a runtime deployment failure — hypothesis-first from log_tail, with bounded branches for non-smoke vs smoke_test failures and a sweep fallback. Loaded by the runtime-diagnoser subagent; do not invoke from the main session.
 ---
 
 # Runtime diagnosis
@@ -12,7 +12,8 @@ minimal file edit. You **do not** touch the cluster.
 
 ## Tools you have
 
-- `Read` — project files (chart values, Dockerfile, session log).
+- `Read` — project files (chart values, Dockerfile, smoke test source,
+  session log).
 - `WebSearch` — upstream documentation when error messages reference
   unfamiliar concepts.
 - `mcp__kagent__k8s_*` — read-only cluster queries.
@@ -20,25 +21,120 @@ minimal file edit. You **do not** touch the cluster.
 
 No `Write`, no `Edit`, no `Bash`, no `kubectl`/`helm`/`docker`.
 
-## Investigation order
+## Hypothesis-first principle
 
-Always proceed in this order — skipping a step risks misdiagnosis:
+Your prompt already contains `verify_runtime_response.checks[*]` —
+each failed check has a `log_tail` (up to 2000 chars of the failed
+command's combined stdout/stderr). **That payload is the cheapest
+source of signal you have.** Read it first; form a single hypothesis;
+then spend cluster queries reluctantly, only on what would *falsify*
+the hypothesis.
 
-1. **Session log tail.** `Read` the last ~200 lines of
-   `session_log`. The first `[exit N]` line before "verify-runtime"
-   shows the command that failed and its stderr.
-2. **Events.** `k8s_get_events -n <namespace>` filtered by the
-   service label. Warnings show scheduling, image pull, and CRD
-   issues before pod state does.
-3. **Describe.** `k8s_describe_resource` on the deployment /
-   statefulset / daemonset. Look for `Events:` at the bottom and
-   the `Conditions:` block.
-4. **Pod logs.** `k8s_get_pod_logs` on any pod in a terminal state
+A full sweep (events → describe → logs → connectivity for every
+failure) is a **fallback** for when log_tail is non-semantic — not the
+default path. Most simple failures (timeout, ImagePullBackOff, missing
+config key) resolve from log_tail alone with 0–2 cluster queries.
+
+## Step 0 — read what's already in the prompt
+
+1. Find the first entry in `verify_runtime_response.checks` with
+   `status == "fail"`. That is your `failed_check`.
+2. Read `failed_check.log_tail`. Decide whether it is:
+   - **semantic** — contains a clear error message, a `FAIL:` line, a
+     stack trace, or a named cluster condition (e.g.
+     `ImagePullBackOff`, `timed out waiting for the condition`).
+   - **non-semantic** — empty, only shell trace fragments, only an
+     exit code, or truncated mid-message.
+3. Branch:
+   - `failed_check.name == "smoke_test"` → **Branch B**.
+   - any other check name with semantic log_tail → **Branch A**.
+   - non-semantic log_tail with no clear branch fit → **Fallback
+     sweep**.
+
+You generally do **not** need to `Read` `session_log` first — it
+contains the same tail with extra surrounding noise. Only fall back to
+it when 2000 chars truncated mid-message and you need the prior lines.
+
+## Branch A — non-smoke failure (hypothesis-first)
+
+Applies to `helm_install`, `kubectl_wait`, `docker_build`, etc.
+
+1. **Form one hypothesis** from `log_tail`. Keep it in your working
+   notes (do not emit yet). Examples:
+   - "helm timed out at 60s — service cold start exceeds default."
+   - "ImagePullBackOff — image tag missing from registry."
+   - "values-dev.yaml missing scrape_configs key."
+2. **Load domain knowledge** if the hypothesis touches
+   technology-specific behavior. See "Domain knowledge before web
+   search" below.
+3. **Falsify with the minimum cluster query** — pick the *one* call
+   that would most cleanly disprove the hypothesis:
+   - timeout hypothesis → `k8s_describe_resource` on the
+     pod/statefulset to read startup duration / events.
+   - image hypothesis → `k8s_get_events -n <ns>` filtered for
+     `Failed` / `BackOff`.
+   - config hypothesis → `Read` the chart values file directly; no
+     cluster query needed.
+4. If the query confirms the hypothesis → proceed to "Proposing a
+   file edit". If it disproves → form a *new* hypothesis from the
+   new evidence and repeat. **Cap at 3 hypothesis cycles** before
+   downgrading to Fallback sweep.
+
+## Branch B — smoke_test failure (bounded)
+
+Pods passed `kubectl_wait` but the smoke test exited non-zero. The
+fix is almost always *human review of the test or the deployed
+service*, not an agent edit. Your job is to pinpoint **exactly which
+assertion failed and what the actual observed value was** so the
+human can decide. Total budget: 1 `Read` + 1 cluster query.
+
+1. **Read the smoke test source** — exactly one file:
+   `{{workspace_dir}}/tests/<phase>/smoke-test-<service>.sh`. Locate
+   the labeled section that failed by correlating the `FAIL: <항목>:
+   ...` line from `log_tail` with the `── N. <항목> ──` headers in
+   the script.
+2. **One cluster query for disambiguation** —
+   `k8s_get_resources` on pods filtered by service label, to confirm
+   `Ready=True`.
+   - `Ready=False` → reclassify as Branch A; pods are unhealthy and
+     the smoke fail is downstream. Continue from Branch A step 1.
+   - `Ready=True` → confirm `failure_source = "smoke_test"`.
+3. **Build observations that pinpoint three things**:
+   - **Where** — file path + section label and approximate line
+     range.
+   - **Why** — the `FAIL: <reason>` message extracted from
+     `log_tail`.
+   - **Actual observed value** — whatever the smoke test printed
+     before exiting (the template asks authors to print this on the
+     line after `FAIL:`). If the smoke test emitted no actual value,
+     **say so explicitly** — that itself is actionable feedback for
+     the human (the test should be improved per the template
+     convention).
+4. **`proposed_files` MUST be empty** in this branch. Smoke tests
+   encode acceptance criteria; auto-patching them defeats their
+   purpose. Use `suggestions` to offer the dichotomy the human must
+   resolve, e.g. "either the readiness probe is too lax (chart fix)
+   or the smoke test should retry / loosen its assertion (test fix)".
+
+## Fallback sweep
+
+Use only when both branches above stall — typically a non-semantic
+log_tail on a non-smoke failure, or a smoke fail where the test
+emitted no information. Run in order; **stop as soon as the cause is
+clear** (do not finish the list for completeness):
+
+1. **Session log full read** — `Read` more of `session_log` than the
+   2000-char tail captured.
+2. **Events** — `k8s_get_events -n <namespace>` filtered by service
+   label. Warnings show scheduling, image pull, and CRD issues
+   before pod state does.
+3. **Describe** — `k8s_describe_resource` on the deployment /
+   statefulset / daemonset. Look at `Events:` and `Conditions:`.
+4. **Pod logs** — `k8s_get_pod_logs` on any pod in a terminal state
    (`CrashLoopBackOff`, `Error`, `ImagePullBackOff`, …). Tail size
    200 is usually sufficient.
-5. **Connectivity.** If the failure is a smoke test or a readiness
-   probe timeout, `k8s_check_service_connectivity` to confirm the
-   Service routes to a ready endpoint.
+5. **Connectivity** — `k8s_check_service_connectivity` if the
+   failure is a network call or readiness probe timeout.
 
 ## Classifying `failure_source`
 
@@ -50,10 +146,11 @@ Return exactly one of:
   - config key missing in `values-dev.yaml`
   - container `ENTRYPOINT` crashes at start
   - probe endpoint path wrong
-- **`smoke_test`** — cluster resources are healthy (all pods Ready,
-  service routes traffic) but the smoke test script
+- **`smoke_test`** — pods are `Ready` and the cluster routes traffic,
+  but the smoke test script
   (`{{workspace_dir}}/tests/<phase>/smoke-test-<service>.sh`) exits
-  non-zero. The fix is a human reviewing the test, not an agent.
+  non-zero. The fix is a human reviewing the test or the deployed
+  service. `proposed_files` must be empty.
 - **`environment`** — root cause is outside the service's own files:
   missing namespace quota, missing secret, broken DNS, upstream
   dependency down. Report with `suggestions`; do not propose edits

--- a/harness/templates/{{workspace_dir}}/tests/_template.sh.tmpl
+++ b/harness/templates/{{workspace_dir}}/tests/_template.sh.tmpl
@@ -17,6 +17,17 @@
 #   exit 0   → smoke_test=pass
 #   exit 비0 → smoke_test=fail  (stdout+stderr 가 detail 로 기록됨)
 #
+# 실패 메시지 형식 (runtime-diagnoser 진단 비용을 좌우):
+#   각 assertion 은 실패 시 stdout 에 다음 두 줄을 남긴 뒤 exit 1.
+#
+#     echo "FAIL: <섹션 라벨>: <짧은 사유>"
+#     echo "  actual: <실제 관측값>"   # 응답 본문, kubectl 출력, 마지막 시도 결과 등
+#
+#   이 두 줄이 verify_runtime_response.checks[].log_tail (2000자) 안에
+#   들어가서 diagnoser 의 1차 단서가 됩니다. 이걸 안 남기면 어떤
+#   assertion 이 왜 실패했는지 알 수 없어 cluster sweep 으로 강등되고,
+#   그 비용은 호출자(/deploy 사용자) 가 토큰으로 부담합니다.
+#
 # 실행시간 규칙:
 #   - 스크립트 전체 실행시간 120s 이내
 #   - retry loop 은 (반복횟수 × sleep 간격) ≤ 120s 로 설계
@@ -53,15 +64,53 @@ NS="${NAMESPACE:?NAMESPACE env not injected by runtime}"
 #   INTERVAL=10
 #   RESULT=""
 #   for i in $(seq 1 $RETRIES); do
-#     RESULT=$(some_command 2>/dev/null || true)
+#     RESULT=$(some_command 2>&1 || true)
 #     [ -n "$RESULT" ] && break
 #     echo "attempt $i/$RETRIES: not ready, waiting ${INTERVAL}s..."
 #     sleep $INTERVAL
 #   done
-#   [ -n "$RESULT" ] || { echo "FAIL: <항목> not ready after $((RETRIES * INTERVAL))s"; exit 1; }
+#   [ -n "$RESULT" ] || {
+#     echo "FAIL: <항목>: not ready after $((RETRIES * INTERVAL))s"
+#     echo "  actual: <last attempt output or 'no response'>"
+#     exit 1
+#   }
+
+# ── "actual" 패턴 가이드 ──────────────────────────────────────────────────────
+# 변수 이름은 무관. assertion 의 비교 대상이 되는 관측값을 "  actual:" 다음에
+# 그대로 출력하면 됩니다. 테스트 종류에 따라 어떤 값을 적을지 달라집니다 —
+# 아래 패턴 중 가장 가까운 걸 골라 쓰세요.
+#
+# (a) HTTP body grep:
+#     RESULT=$(curl -sf "$URL" 2>&1 || true)
+#     echo "$RESULT" | grep -q "<expected>" || {
+#       echo "FAIL: <항목>: response did not contain '<expected>'"
+#       echo "  actual: $RESULT"
+#       exit 1
+#     }
+#
+# (b) HTTP status code:
+#     STATUS=$(curl -s -o /tmp/body -w "%{http_code}" "$URL")
+#     [ "$STATUS" = "200" ] || {
+#       echo "FAIL: <항목>: expected HTTP 200"
+#       echo "  actual: HTTP $STATUS, body=$(cat /tmp/body 2>/dev/null || echo '')"
+#       exit 1
+#     }
+#
+# (c) kubectl + jq (자원 수, status field 등 구조화된 결과):
+#     COUNT=$(kubectl get pod -n "$NS" -l app="$SERVICE" -o json \
+#       | jq '[.items[] | select(.status.phase=="Running")] | length')
+#     [ "$COUNT" -ge 3 ] || {
+#       echo "FAIL: <항목>: expected >=3 Running pods"
+#       echo "  actual: $COUNT pods"
+#       exit 1
+#     }
+#
+# (d) multi-step: 각 단계별 출력을 따로 캡처하고, 실패한 단계의 출력만
+#     "actual:" 에 담을 것. e.g. login 토큰 발급 실패 → 토큰 응답 본문을
+#     출력. 후속 API 호출 실패 → 그 호출의 응답 본문을 출력.
 
 # ── 1. <검증 항목> ────────────────────────────────────────────────────────────
-# <command> || { echo "FAIL: <reason>"; exit 1; }
+# (위 (a)-(d) 패턴 중 하나를 골라 작성)
 
 # ── 2. <검증 항목> ────────────────────────────────────────────────────────────
-# <command> || { echo "FAIL: <reason>"; exit 1; }
+# (위 (a)-(d) 패턴 중 하나를 골라 작성)


### PR DESCRIPTION
## 변경 사항
현재 런타임 검증 실패시 runtime-diagnoser에게 log와 함께 호출하게되는데, 이때 skill에서는 해당 log를 강조하지 않고 tool호출을 통한 문제 원인 추론을 요구하는 상황이 발생.

skill에서 log를 통한 가설 설정을 진행하도록 명시하여 토큰 사용을 절감.

## 주요 작업 내용
- [x] `.claude/skills/runtime-diagnosis/SKILL.md.tmpl`을 수정하여 가설 설정을 명시화
- [x] `.claude/agents/runtime-diagnoser.md.tmpl`의 workflow를 skill과 맞춤
- [x] {`{workspace_dir}}/tests/_template.sh.tmpl`를 수정하여 smoke test에서 반환하는 정보를 강화

## 관련 이슈 번호
- Closes #16 

## 테스트 결과
.