### PR TITLE
fix(runtime): skip pod readiness wait for batch-only (Job/CronJob) ch…

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -122,7 +122,11 @@ DOCKER_CHECKS = {hadolint, gitleaks_docker}
 
 **`verify_runtime(service, cfg, *, phase)`** — 배포 후:
 
-1. **CRD-only chart 감지.** `helm template` 을 돌려 렌더된 YAML 을 파싱. `kind` 가 `{Deployment, StatefulSet, DaemonSet, ReplicaSet, Job, CronJob, Pod}` 중 하나도 없으면 CRD-only chart 로 간주해 `kubectl_wait` 를 skip. template 실패 시엔 "workload 있음"으로 보수적으로 처리 — 레거시 동작 보존.
+1. **workload class 감지.** `helm template` 을 돌려 렌더된 YAML 을 파싱.
+   - long-running workload(`Deployment, StatefulSet, DaemonSet, ReplicaSet, Pod`) 가 하나도 없으면:
+     - batch workload(`Job, CronJob`) 도 없음 → CRD-only chart 로 간주해 `kubectl_wait` skip.
+     - batch workload 만 있음 → batch-only chart (steady-state 로 `Ready` 가 되는 파드가 없음) → `kubectl_wait` skip. 스모크 테스트는 그대로 실행.
+   - template 실패 / YAML 파싱 실패 시엔 "long-running workload 있음"으로 보수적으로 처리 — 레거시 동작 보존.
 
 2. **2단계 kubectl wait.** 2-phase wait 패턴:
    - 1차 probe: `kubectl wait pods --for=condition=Ready --timeout=<initial_wait_seconds>s`

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -382,7 +382,7 @@ def run(cmd: list[str], *,
 - `verify_runtime()` 흐름:
   1. `chart_path.exists()` →
      - `kubectl wait` 2단계: `initial_wait_seconds` 대기 → pod 상태 조회 → terminal(`CrashLoopBackOff`, `ImagePullBackOff`, `ErrImagePull`, `Error`, `OOMKilled`) 감지 시 즉시 fail, 아니면 `terminal_grace_seconds` 추가 대기
-     - `helm template` 분석 후 workload 리소스가 없는 CRD-only chart 는 자동 skip
+     - `helm template` 분석 후 long-running workload 가 없는 chart 는 `kubectl wait` 자동 skip — workload 가 아예 없으면 CRD-only, `Job`/`CronJob` 만 있으면 batch-only (둘 다 steady-state 파드 없음)
   2. `smoke_test_path` 존재 → 실행 (kubectl wait 실패 시 skip)
   3. `chart_path` 없고 `docker_path` 만 존재 → push 성공 여부가 runtime 통과
 
@@ -913,10 +913,11 @@ terminal_states = {"CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull",
    - 타임아웃 → fail
 ```
 
-CRD-only chart skip:
+CRD-only / batch-only chart skip:
 - `helm template <chart>` 실행 후 출력 YAML 의 `kind` 필드 수집
-- workload kind 가 `{Deployment, StatefulSet, DaemonSet, Job, CronJob, Pod, ReplicaSet}` 중 하나라도 있으면 대기
-- 전부 CRD/RBAC/ConfigMap/Secret 류면 kubectl wait skip → pass
+- long-running workload(`{Deployment, StatefulSet, DaemonSet, ReplicaSet, Pod}`) 가 하나라도 있으면 대기
+- long-running workload 가 없고 `Job`/`CronJob` 만 있으면 batch-only → kubectl wait skip → pass (스모크는 실행)
+- 전부 CRD/RBAC/ConfigMap/Secret 류면 CRD-only → kubectl wait skip → pass
 
 ### 21.4 Smoke test 실행 규약
 

--- a/harness/runtime.py
+++ b/harness/runtime.py
@@ -12,7 +12,8 @@ Preserved from the legacy ``runtime_gates.py`` (refactor.md §21):
 - ``helm uninstall`` before ``helm upgrade --install`` (immutable field workaround)
 - ``kubectl wait`` 2-stage: ``initial_wait_seconds`` probe → terminal-state detection
   → ``terminal_grace_seconds`` grace window
-- CRD-only chart auto-skip (parse ``helm template`` stdout for workload kinds)
+- CRD-only and batch-only (Job/CronJob) charts skip the pod readiness wait
+  (parse ``helm template`` stdout for workload kinds)
 - Smoke test env injection (SERVICE, NAMESPACE, RELEASE_NAME, ACTIVE_ENV, DOMAIN_SUFFIX)
 """
 
@@ -36,12 +37,16 @@ _TERMINAL_STATES = frozenset({
     "Error", "OOMKilled", "InvalidImageName", "CreateContainerConfigError",
 })
 
-# kinds that require pod readiness waiting; if chart contains none of these
-# the chart is CRD-only and kubectl wait is skipped
-_WORKLOAD_KINDS = frozenset({
-    "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet",
-    "Job", "CronJob", "Pod",
+# workload kinds whose pods reach a steady-state ``Ready`` condition — these are
+# the only ones ``kubectl wait --for=condition=Ready`` can meaningfully wait on
+_LONGRUNNING_WORKLOAD_KINDS = frozenset({
+    "Deployment", "StatefulSet", "DaemonSet", "ReplicaSet", "Pod",
 })
+# one-shot / scheduled workloads — their pods never become ``Ready`` (they end
+# ``Succeeded``, or are deleted by a Helm hook delete-policy)
+_BATCH_WORKLOAD_KINDS = frozenset({"Job", "CronJob"})
+# any workload kind; a chart rendering none of these is CRD-only
+_WORKLOAD_KINDS = _LONGRUNNING_WORKLOAD_KINDS | _BATCH_WORKLOAD_KINDS
 
 
 # ─── helpers ─────────────────────────────────────────────────────────────────
@@ -187,12 +192,15 @@ def apply(service: str, cfg: Config) -> list[CheckResult]:
 # ─── verify_runtime ──────────────────────────────────────────────────────────
 
 
-def _chart_has_workloads(rs: ResolvedService, cfg: Config) -> bool:
-    """Parse ``helm template`` output; return True if any workload kind is rendered.
+def _chart_workload_classes(rs: ResolvedService, cfg: Config) -> tuple[bool, bool]:
+    """Parse ``helm template`` output → ``(has_longrunning, has_batch)``.
 
-    On template failure (network, missing deps, etc.) we default to True so
-    kubectl wait still runs — a conservative choice that preserves behavior
-    of the legacy ``runtime_gates.py``.
+    ``has_longrunning`` is True if the chart renders any Deployment/StatefulSet/
+    DaemonSet/ReplicaSet/Pod; ``has_batch`` if it renders any Job/CronJob.
+
+    On template failure (network, missing deps, etc.) or unparseable YAML we
+    default to ``(True, False)`` so kubectl wait still runs — a conservative
+    choice that preserves behavior of the legacy ``runtime_gates.py``.
     """
     cmd = [
         "helm", "template", rs.release_name, str(rs.chart_path),
@@ -201,14 +209,20 @@ def _chart_has_workloads(rs: ResolvedService, cfg: Config) -> bool:
     ]
     r = shell.run(cmd, label="verify-runtime/helm_template", log_stdout=False)
     if not r.ok:
-        return True
+        return True, False
+    longrunning = batch = False
     try:
-        return any(
-            isinstance(doc, dict) and doc.get("kind") in _WORKLOAD_KINDS
-            for doc in yaml.safe_load_all(r.stdout)
-        )
+        for doc in yaml.safe_load_all(r.stdout):
+            if not isinstance(doc, dict):
+                continue
+            kind = doc.get("kind")
+            if kind in _LONGRUNNING_WORKLOAD_KINDS:
+                longrunning = True
+            elif kind in _BATCH_WORKLOAD_KINDS:
+                batch = True
     except yaml.YAMLError:
-        return True
+        return True, False
+    return longrunning, batch
 
 
 def _pods_sidecar_path() -> Path | None:
@@ -271,6 +285,11 @@ def _detect_terminal_failure(
 
 
 def _kubectl_wait(rs: ResolvedService, timeout_seconds: int) -> shell.RunResult:
+    # NOTE: this waits on *all* pods matching ``label_selector``. A chart that
+    # mixes a Deployment with a Job/CronJob (or a lingering Helm-hook Job pod)
+    # under the same labels can stall here — batch pods never go ``Ready``. The
+    # proper fix is to wait on workload resources (Deployment --for=
+    # condition=Available) rather than pods; tracked as a follow-up refactor.
     return shell.run(
         [
             "kubectl", "wait", "pods",
@@ -343,6 +362,10 @@ def verify_runtime(
 
     ``phase`` selects the smoke test file (combined with ``service``).
     If missing, smoke test is skipped.
+
+    ``kubectl wait`` is skipped for CRD-only charts and for batch-only charts
+    (only Job/CronJob workloads) — neither has steady-state pods to wait on —
+    while the smoke test still runs.
     """
     rs = cfg.resolve(service)
     has_helm = rs.chart_path.is_dir()
@@ -360,17 +383,25 @@ def verify_runtime(
     if has_helm:
         if not cfg.checks.runtime.kubectl_wait.enabled:
             results.append(_skip("kubectl_wait", "disabled in config"))
-        elif not _chart_has_workloads(rs, cfg):
-            results.append(CheckResult(
-                name="kubectl_wait",
-                status="skip",
-                detail="CRD-only chart: no workload resources",
-            ))
         else:
-            kw = _kubectl_wait_staged(rs, cfg)
-            results.append(kw)
-            if kw.status == "fail":
-                smoke_allowed = False
+            has_longrunning, has_batch = _chart_workload_classes(rs, cfg)
+            if not has_longrunning and not has_batch:
+                results.append(CheckResult(
+                    name="kubectl_wait",
+                    status="skip",
+                    detail="CRD-only chart: no workload resources",
+                ))
+            elif not has_longrunning:  # only Job/CronJob workloads
+                results.append(CheckResult(
+                    name="kubectl_wait",
+                    status="skip",
+                    detail="batch-only chart (Job/CronJob): no steady-state pods to wait on",
+                ))
+            else:
+                kw = _kubectl_wait_staged(rs, cfg)
+                results.append(kw)
+                if kw.status == "fail":
+                    smoke_allowed = False
 
     if not cfg.checks.runtime.smoke_test:
         results.append(_skip("smoke_test", "disabled in config"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kubeharness"
-version = "2.0.0"
+version = "2.0.1"
 description = "Deterministic Kubernetes deploy/verify CLI + agent wiring templates"
 requires-python = ">=3.11"
 dependencies = [

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -133,6 +133,22 @@ _CRD_YAML = (
     "metadata:\n  name: foos.example.com\n"
 )
 
+_CRONJOB_YAML = (
+    "apiVersion: batch/v1\n"
+    "kind: CronJob\n"
+    "metadata:\n  name: svc\n"
+)
+
+_HOOK_JOB_YAML = (
+    "apiVersion: batch/v1\n"
+    "kind: Job\n"
+    "metadata:\n"
+    "  name: svc-migrate\n"
+    "  annotations:\n    helm.sh/hook: post-install\n"
+)
+
+_DEPLOY_PLUS_CRONJOB_YAML = _DEPLOY_YAML + "---\n" + _CRONJOB_YAML
+
 
 def test_verify_runtime_crd_only_chart_skips_kubectl_wait(cfg, helm_chart, stub):
     stub.set("verify-runtime/helm_template", stdout=_CRD_YAML)
@@ -142,12 +158,58 @@ def test_verify_runtime_crd_only_chart_skips_kubectl_wait(cfg, helm_chart, stub)
     assert "CRD-only" in (kw.detail or "")
 
 
+def test_verify_runtime_cronjob_only_chart_skips_wait_but_runs_smoke(
+    cfg, helm_chart, stub, tmp_path
+):
+    stub.set("verify-runtime/helm_template", stdout=_CRONJOB_YAML)
+    smoke_path = tmp_path / "ws" / "tests" / "p1"
+    smoke_path.mkdir(parents=True)
+    (smoke_path / "smoke-test-svc.sh").write_text("#!/bin/bash\nexit 0\n")
+    results = runtime.verify_runtime("svc", cfg, phase="p1")
+    kw = next(r for r in results if r.name == "kubectl_wait")
+    assert kw.status == "skip"
+    assert "batch-only" in (kw.detail or "")
+    # batch-only skip must not block the smoke test
+    smoke = next(r for r in results if r.name == "smoke_test")
+    assert smoke.status == "pass"
+    assert any(label == "verify-runtime/smoke_test" for label, _ in stub.calls)
+    # no kubectl wait should have been attempted
+    assert not any(label == "verify-runtime/kubectl_wait" for label, _ in stub.calls)
+
+
+def test_verify_runtime_hook_job_only_chart_skips_wait(cfg, helm_chart, stub):
+    stub.set("verify-runtime/helm_template", stdout=_HOOK_JOB_YAML)
+    results = runtime.verify_runtime("svc", cfg)
+    kw = next(r for r in results if r.name == "kubectl_wait")
+    assert kw.status == "skip"
+    assert "batch-only" in (kw.detail or "")
+
+
+def test_verify_runtime_deployment_plus_cronjob_still_waits(cfg, helm_chart, stub):
+    stub.set("verify-runtime/helm_template", stdout=_DEPLOY_PLUS_CRONJOB_YAML)
+    stub.set("verify-runtime/kubectl_wait", exit_code=0)
+    results = runtime.verify_runtime("svc", cfg)
+    kw = next(r for r in results if r.name == "kubectl_wait")
+    assert kw.status == "pass"
+    assert any(label == "verify-runtime/kubectl_wait" for label, _ in stub.calls)
+
+
 def test_verify_runtime_kubectl_wait_pass(cfg, helm_chart, stub):
     stub.set("verify-runtime/helm_template", stdout=_DEPLOY_YAML)
     stub.set("verify-runtime/kubectl_wait", exit_code=0)
     results = runtime.verify_runtime("svc", cfg)
     kw = next(r for r in results if r.name == "kubectl_wait")
     assert kw.status == "pass"
+
+
+def test_verify_runtime_helm_template_failure_waits_conservatively(cfg, helm_chart, stub):
+    # helm template fails → assume workloads present → kubectl wait still runs
+    stub.set("verify-runtime/helm_template", exit_code=1, stderr="template error")
+    stub.set("verify-runtime/kubectl_wait", exit_code=0)
+    results = runtime.verify_runtime("svc", cfg)
+    kw = next(r for r in results if r.name == "kubectl_wait")
+    assert kw.status == "pass"
+    assert any(label == "verify-runtime/kubectl_wait" for label, _ in stub.calls)
 
 
 def test_verify_runtime_terminal_state_early_exit(cfg, helm_chart, stub):


### PR DESCRIPTION
## 변경 사항
 batch 워크로드(`Job`/`CronJob`)만 렌더하는 차트가 `verify-runtime`에서 `kubectl wait`로 인해 실패하던 문제를 수정. 워크로드 kind를long-running(`Deployment`/`StatefulSet`/`DaemonSet`/`ReplicaSet`/`Pod`)과 batch(`Job`/`CronJob`)로 분리하고, batch-only 차트는 CRD-only 차트처럼 `kubectl_wait`를 skip하되 `smoke_test`는 그대로 실행하도록 변경.
## 주요 작업 내용
- [x] `_WORKLOAD_KINDS` → `_LONGRUNNING_WORKLOAD_KINDS` + `_BATCH_WORKLOAD_KINDS`로 분리 (`_WORKLOAD_KINDS`는 합집합으로 호환 유지)
- [x] `_chart_has_workloads` → `_chart_workload_classes(rs, cfg) ->(has_longrunning, has_batch)`
- [x] `verify_runtime`: 워크로드 없음→`skip "CRD-only chart"` / batch만→`skip "batch-only chart (Job/CronJob)"` (smoke 실행) / long-running 있음→기존 2단계 wait
- [x] module/`verify_runtime` docstring + `_kubectl_wait` 주석 갱신
- [x] 테스트 추가: CronJob-only, hook Job-only, Deployment+CronJob, helm template 실패(보수) — 회귀 테스트 전부 통과
- [x] `docs/design.md`, `docs/refactor.md` 갱신
- [x] `pyproject.toml` 2.0.0 → 2.0.1

## 관련 이슈 번호
- Closes #18 

## 테스트 결과
.