### PR TITLE
refactor(static): collapse verbose trivy config output to one line

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ CLI 는 아래 도구들을 shell out 해서 사용함. 없는 도구는 해당 
 | `yamllint` | chart YAML hygiene (pip 의존성으로 자동 포함) |
 | `kubeconform` | k8s 스키마 검증 (`helm template \| kubeconform`) |
 | `hadolint` | Dockerfile lint |
-| `trivy` | chart config scan (선택) |
+| `trivy` | chart config scan (선택) — 출력 요약에 `jq` 필요 |
 | `gitleaks` | 시크릿 스캔 (선택) |
 
 각 도구 설치법은 upstream 문서 참조. Kubeharness 는 설치 스크립트를 동봉하지 않음.

--- a/docs/design.md
+++ b/docs/design.md
@@ -85,7 +85,7 @@ cfg.checks.runtime.kubectl_wait.initial_wait_seconds  # int
 - **CLI 미설치 처리** — 예외를 던지는 대신 `exit_code=-1` + stderr `"command not found: X"` 를 반환. 호출자가 exception 핸들링 없이 `skip` 으로 분류할 수 있음.
 - **PATH 보강** — `~/.local/bin` 을 prepend 해서 `pip install --user` 나 언어별 패키지 매니저가 깐 도구를 찾도록 함.
 
-`shell.pipe(a, b)` 는 같은 로깅 규약으로 `a | b` 를 실행함 — `helm template | kubeconform` 에서 사용.
+`shell.pipe(a, b)` 는 같은 로깅 규약으로 `a | b` 를 실행함 — `helm template | kubeconform`, `trivy config --format json | jq` 에서 사용.
 
 ### `static.py`
 

--- a/harness/static.py
+++ b/harness/static.py
@@ -121,9 +121,21 @@ def check_kubeconform(rs: ResolvedService, cfg: Config) -> CheckResult:
     return _from_result("kubeconform", r, cfg.logging.tail_chars)
 
 
+# Collapse trivy's verbose table output (per-finding description + code snippet)
+# into one line per misconfiguration: "<id> <severity> <file>:<start>-<end>  <message>".
+# The message is finding-specific ("Container 'manager' ... should set ..."), so it
+# stays actionable; the rule id reconstructs the AVD url if more detail is needed.
+_TRIVY_JQ = (
+    r'.Results[]? | .Target as $t | .Misconfigurations[]? '
+    r'| "\(.ID) \(.Severity) \($t):\(.CauseMetadata.StartLine)-\(.CauseMetadata.EndLine)  \(.Message)"'
+)
+
+
 def check_trivy_config(rs: ResolvedService, cfg: Config) -> CheckResult:
-    r = shell.run(
-        ["trivy", "config", "--exit-code", "1", str(rs.chart_path)],
+    r = shell.pipe(
+        ["trivy", "config", "--quiet", "--skip-version-check",
+         "--format", "json", "--exit-code", "1", str(rs.chart_path)],
+        ["jq", "-r", _TRIVY_JQ],
         label="static/trivy_config",
     )
     return _from_result("trivy_config", r, cfg.logging.tail_chars)


### PR DESCRIPTION
## 변경 사항
`trivy config` 의 기본 table 출력이 misconfiguration 마다 설명문 + 코드 스니펫을 넣어 배포 세션 로그를 지배함 (findings 9개 차트 기준 약 240줄) → 에이전트가 읽을 때 토큰 낭비. `trivy config --format json | jq` 로 finding 당 한 줄로 압축함.

- 출력 형식: `<id> <severity> <file>:<start>-<end>  <message>`
- `message` 는 finding 전용("Container 'manager' ... should set ...")이라 그대로 actionable
- 더 자세한 설명은 rule id 로 AVD url(`avd.aquasec.com/misconfig/<id>`) 재구성
- `--quiet` 로 `[misconfig] ... enabled` 류 INFO 줄, `--skip-version-check` 로 버전 업데이트 알림 제거
- jq 가 없으면 `trivy_config` 체크는 `skip` 으로 떨어짐(이미 optional 체크). README prerequisites 표와 `docs/design.md` 의 `shell.pipe` 사용처 설명 갱신

## 주요 작업 내용
- [x] `harness/static.py`: `check_trivy_config` 를 `shell.run` → `shell.pipe(trivy …, jq …)` 로 변경, `--quiet --skip-version-check -format json` 추가
- [x] `README.md`: prerequisites 표 `trivy` 행에 "출력 요약에 `jq` 필요" 명시
- [x] `docs/design.md`: `shell.pipe` 사용처에 `trivy config --format json | jq` 추가

## 관련 이슈 번호
- Closes #20 

## 테스트 결과
- jq 필터를 샘플 trivy JSON 으로 검증 → finding 당 한 줄 출력 확인
- `gikview/edge/helm/step-issuer` 로 실제 실행 → 현재 findings 0 (exit 0), jq 출력 빈 문자열 → `_from_result` 에서 `pass` 처리 확인
- pipe exit code: trivy 가 findings 있으면 1, jq(0) 여도 `p2.returncode or p1.returncode` 로 1 유지 → `fail` + log_tail 에 한 줄 요약 들어감
- `ast.parse(harness/static.py)` 통과 (이 환경에 pytest 미설치라 단위테스트 미실행 — `test_static.py` 는 trivy_config 가 fixture 에서 disabled 라 skip 경로만 타므로 영향 없음)