### PR TITLE
feat(runtime): multi-arch buildx for self-built images; image_tag default → latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CLI 는 아래 도구들을 shell out 해서 사용함. 없는 도구는 해당 
 |---|---|
 | `helm` (v3) | chart lint, template, upgrade, uninstall |
 | `kubectl` | 배포 후 wait, pod 조회 |
-| `docker` (+ buildx) | 이미지 build · push |
+| `docker` + `buildx` | 자가 빌드 이미지 multi-arch build · push (아래 "multi-arch 이미지 빌드" 참조) |
 | `yamllint` | chart YAML hygiene (pip 의존성으로 자동 포함) |
 | `kubeconform` | k8s 스키마 검증 (`helm template \| kubeconform`) |
 | `hadolint` | Dockerfile lint |
@@ -38,6 +38,43 @@ CLI 는 아래 도구들을 shell out 해서 사용함. 없는 도구는 해당 
 - `asdf`/`mise` 등 버전 매니저: 각 툴 shim 경로
 
 검사 결과는 `python -m harness verify-static --service <svc>` JSON 응답의 `status` 로 확인.
+
+#### multi-arch 이미지 빌드 (자가 빌드 서비스)
+
+`{workspace}/docker/<service>/Dockerfile` 이 있는 서비스는 `apply` 단계에서
+`docker buildx build --platform <conventions.build_platforms> -t <img> --push`
+한 번으로 빌드+푸시됨 (멀티플랫폼 이미지는 manifest list 라 로컬 `docker load`
+불가 → 곧장 레지스트리로 push). `build_platforms` 는 `config/harness.yaml` 의
+`conventions.build_platforms` 로 조정 (기본 `["linux/amd64", "linux/arm64"]`),
+`conventions.registry` 는 비울 수 없음.
+
+빌드를 돌리는 머신(= `/deploy` 를 실행하는 곳)에 **호스트당 1회** 셋업이 필요함.
+Docker Desktop(맥/윈) 사용자는 이미 다 들어 있으니 건너뛰어도 됨 — 아래는 bare
+리눅스 `docker-ce` 기준:
+
+```bash
+# 0. buildx 플러그인 확인 (없으면: apt install docker-buildx-plugin 등)
+docker buildx version
+
+# 1. 외래 arch 에뮬레이션 핸들러 등록 (privileged — 커널에 등록, 재부팅 전까지 유지)
+docker run --privileged --rm tonistiigi/binfmt --install all
+
+# 2. multi-platform 빌드 가능한 빌더 생성 + 기본으로 지정 (영구)
+docker buildx create --name multiarch --driver docker-container --bootstrap --use
+
+# 확인: platforms 줄에 linux/amd64, linux/arm64 (+ 빌드 대상들) 이 떠야 함
+docker buildx inspect --bootstrap
+```
+
+- 재부팅하면 binfmt 핸들러가 사라질 수 있음 → `docker buildx inspect` 에 외래
+  arch 가 안 보이면 1번만 다시 실행 (영구화하려면 `qemu-user-static` +
+  `binfmt-support` 패키지 또는 systemd 유닛).
+- 빌더 컨테이너(`multiarch`)는 영구임 — 재부팅 후 stopped 여도 `--bootstrap` 이
+  알아서 깨움.
+- 레지스트리 인증은 CLI 가 안 함 — `apply` 전에 셸에서 `docker login <registry>`
+  해 둘 것 (buildx `--push` 가 레지스트리에 직접 쓰므로 빌드 *전* 에 필요).
+- 크로스 arch 빌드는 QEMU 에뮬레이션이라 느림(컴파일 무거우면 체감). 네이티브
+  빌더(원격 arm64 노드)를 `docker buildx create --append` 로 붙이면 빨라짐.
 
 #### kagent (선택)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -112,7 +112,7 @@ DOCKER_CHECKS = {hadolint, gitleaks_docker}
 
 **`apply(service, cfg)`** — 배포 흐름:
 
-1. `docker/<svc>/Dockerfile` 존재 시: `docker build --platform linux/{arch}` (arch 는 active env 에서) → `docker push`. build 실패 시 중단, 이후 단계는 `skip`.
+1. `docker/<svc>/Dockerfile` 존재 시: `docker buildx build --platform <conventions.build_platforms> -t <img> --push <docker_path>` — multi-arch manifest list 라 build+push 가 한 명령(멀티플랫폼 이미지는 로컬 `docker load` 불가, 곧장 레지스트리로 push). `conventions.registry` 가 비면 이 단계는 `fail`. build 실패 시 중단, 이후 단계는 `skip`. 호스트에 `docker-container` buildx 빌더(+ 외래 arch 용 binfmt/QEMU)가 있어야 함 — README "사전 준비" 참조.
 2. `helm/<svc>/` 존재 시:
    a. `helm status <release> -n <ns>` 로 기존 릴리스 감지.
    b. 존재하면 `helm uninstall` 먼저. 이전 chart 에 immutable field(예: `spec.selector`)가 있어 `helm upgrade` 가 거부하는 흔한 케이스를 처리함. clean uninstall 후 install 이 가장 단순한 결정적 해법.
@@ -257,7 +257,7 @@ deploy-orchestrator  (subagent — LLM 이 여기 살아있음)
 
 ### 새 environment 추가
 
-1. `config/harness.yaml` 의 `environments.<env>: {domain_suffix, arch, node_selectors}` 에 추가.
+1. `config/harness.yaml` 의 `environments.<env>: {domain_suffix, node_selectors}` 에 추가. (빌드 arch 는 env 가 아니라 `conventions.build_platforms` 에서 정함 — 이미지는 arch-agnostic 이고 env 차이는 도메인/노드/values 에만 둠.)
 2. `environments.active` 를 새 env 로 세팅(또는 CLI 플래그로 넘김 — refactor.md §20 에 따라 아직 미구현).
 3. 각 chart 에 `values-<env>.yaml` 을 추가.
 

--- a/harness/config.py
+++ b/harness/config.py
@@ -64,13 +64,13 @@ class Conventions:
     write_denied_globs: tuple[str, ...]
     registry: str
     image_tag: str
+    build_platforms: tuple[str, ...]
 
 
 @dataclass(frozen=True)
 class Environment:
     name: str
     domain_suffix: str
-    arch: str
     node_selectors: dict[str, str] = field(default_factory=dict)
 
 
@@ -131,6 +131,7 @@ class ResolvedService:
     docker_path: Path
     registry: str
     image_tag: str
+    build_platforms: tuple[str, ...]
     _values_file_patterns: tuple[str, ...]
     _active_env: str
 
@@ -180,6 +181,7 @@ class Config:
             docker_path=Path(c.docker_path.format(**subs)),
             registry=c.registry,
             image_tag=c.image_tag,
+            build_platforms=c.build_platforms,
             _values_file_patterns=c.values_files,
             _active_env=self.active_env,
         )
@@ -229,7 +231,10 @@ def _parse(raw: dict, source: Path) -> Config:
             "{workspace}/tests/**",
         ]),
         registry=str(conv_raw.get("registry", "")),
-        image_tag=str(conv_raw.get("image_tag", "dev")),
+        image_tag=str(conv_raw.get("image_tag", "latest")),
+        build_platforms=tuple(
+            conv_raw.get("build_platforms") or ["linux/amd64", "linux/arm64"]
+        ),
     )
 
     env_raw = _require_dict(raw.get("environments", {}), "environments")
@@ -242,7 +247,6 @@ def _parse(raw: dict, source: Path) -> Config:
         environments[name] = Environment(
             name=name,
             domain_suffix=str(body.get("domain_suffix", "cluster.local")),
-            arch=str(body.get("arch", "amd64")),
             node_selectors=dict(body.get("node_selectors") or {}),
         )
     if active_env not in environments:

--- a/harness/runtime.py
+++ b/harness/runtime.py
@@ -94,28 +94,28 @@ def _docker_apply(rs: ResolvedService, cfg: Config) -> list[CheckResult]:
             CheckResult(
                 name="docker_build",
                 status="fail",
-                detail="config/harness.yaml: conventions.registry is empty",
+                detail="config/harness.yaml: conventions.registry is empty "
+                       "(multi-arch buildx pushes the manifest list straight to a registry)",
             ),
-            _skip("docker_push"),
         ]
-    arch = cfg.active_environment().arch
     image = _docker_image(rs)
+    platforms = ",".join(rs.build_platforms)
 
+    # One `docker buildx build --push`: a multi-platform image is a manifest
+    # list and cannot be `docker load`-ed locally, so build and push are a
+    # single step. Requires a `docker-container` buildx builder (+ binfmt/QEMU
+    # for foreign arches) — see README "사전 준비".
     build = shell.run(
         [
-            "docker", "build",
-            "--platform", f"linux/{arch}",
+            "docker", "buildx", "build",
+            "--platform", platforms,
             "-t", image,
+            "--push",
             str(rs.docker_path),
         ],
         label="apply/docker_build",
     )
-    build_check = _result_from("docker_build", build, cfg)
-    if build_check.status != "pass":
-        return [build_check, _skip("docker_push")]
-
-    push = shell.run(["docker", "push", image], label="apply/docker_push")
-    return [build_check, _result_from("docker_push", push, cfg)]
+    return [_result_from("docker_build", build, cfg)]
 
 
 # ─── helm ────────────────────────────────────────────────────────────────────

--- a/harness/templates/.claude/skills/cluster-env-inject/SKILL.md.tmpl
+++ b/harness/templates/.claude/skills/cluster-env-inject/SKILL.md.tmpl
@@ -17,17 +17,21 @@ environments:
   active: dev
   dev:
     domain_suffix: dev.example.local
-    arch: amd64
     node_selectors:
       storage: node-a
       monitoring: node-b
   prod:
     domain_suffix: cluster.local
-    arch: arm64
     node_selectors:
       storage: node-p1
       monitoring: node-p2
 ```
+
+(There is no `arch` per env — self-built images are multi-arch
+manifest lists built for `conventions.build_platforms`, so each node
+pulls its own variant. Don't add `nodeSelector: kubernetes.io/arch`
+to per-env values either; it's redundant with the hostname pin below
+and risks a scheduling conflict.)
 
 ## What belongs in `values-<env>.yaml`
 

--- a/harness/templates/.claude/skills/docker-author/SKILL.md.tmpl
+++ b/harness/templates/.claude/skills/docker-author/SKILL.md.tmpl
@@ -30,21 +30,30 @@ when `Dockerfile` exists at this path.
 
 ## Build + push flow (handled by the CLI)
 
-The CLI assembles:
+The CLI assembles one multi-arch `buildx` command (build and push are a
+single step — a multi-platform image is a manifest list and can't be
+loaded into the local docker, so it goes straight to the registry):
 
 ```
-docker build \
-  --platform linux/<arch-from-active-env> \
+docker buildx build \
+  --platform <conventions.build_platforms joined by ",">  \
   -t <registry>/<service>:<image-tag> \
+  --push \
   {{workspace_dir}}/docker/<service>
-docker push <registry>/<service>:<image-tag>
 ```
 
 - `registry` ← `conventions.registry` in `config/harness.yaml`
-- `arch` ← `environments.<active>.arch`
+- `build_platforms` ← `conventions.build_platforms` (default `linux/amd64,linux/arm64`)
 - `image-tag` ← `conventions.image_tag`
 
-You do not invoke docker yourself. You only write the Dockerfile.
+You do not invoke docker yourself. You only write the Dockerfile — and
+it must build cleanly on **every** platform in `build_platforms` (no
+arch-specific binary downloads without a `TARGETARCH` switch; `buildx`
+provides `TARGETPLATFORM`/`TARGETARCH`/`TARGETOS` build args).
+
+> The machine running `/deploy` needs a `docker-container` buildx
+> builder (+ binfmt/QEMU for foreign arches) — a one-time host setup.
+> See the project README "사전 준비".
 
 ## Multi-stage template
 
@@ -93,8 +102,9 @@ Do not add global suppressions to the repo root.
 
 ## Registry & push
 
-- `conventions.registry` must be set and reachable by the cluster.
-- Empty string disables push (build only) — useful for smoke tests
-  but never for a real deploy.
+- `conventions.registry` must be set and reachable by the cluster — a
+  multi-arch `buildx --push` pushes the manifest list straight to the
+  registry, so an empty `registry` is a hard error (the docker stage
+  fails), not "build only".
 - The CLI does not log into the registry. Configure credentials in
-  your shell environment before running `/deploy`.
+  your shell environment before running `/deploy` (`docker login …`).

--- a/harness/templates/AGENTS.md.tmpl
+++ b/harness/templates/AGENTS.md.tmpl
@@ -13,8 +13,8 @@ agent **when to use what**.
    through `python -m harness <subcommand>`. The CLI owns timeouts, release
    naming, session logging, and uninstall-before-upgrade.
 2. **Configuration is `config/harness.yaml`.** Never hardcode namespace,
-   workspace path, release name, image tag, or arch in code or skills.
-   Read the YAML at runtime.
+   workspace path, release name, image tag, or build platforms in code or
+   skills. Read the YAML at runtime.
 3. **Workspace writes only.** Code and artifacts go in `{{workspace_dir}}/`.
    `harness/`, `.claude/`, `config/`, `context/`, `docs/` are off-limits —
    the hook will block writes regardless.

--- a/harness/templates/config/harness.yaml.example.tmpl
+++ b/harness/templates/config/harness.yaml.example.tmpl
@@ -28,12 +28,17 @@ conventions:
   # -f 로 이 순서대로 넘기는 values 파일. {active_env} 는 resolve() 시점 바인딩.
   values_files: ["values.yaml", "values-{active_env}.yaml"]
 
-  # docker 이미지 태그. `<registry>/<service>:<tag>` 로 기록됨.
-  # "latest", git sha, semver 등 원하는 값으로 덮어쓸 것.
-  image_tag: "dev"
+  # docker 이미지 태그. `<registry>/<service>:<tag>` 로 기록됨. 자가 빌드 이미지는
+  # multi-arch manifest list 라 arch 별로 태그가 갈리지 않음 — 중립 태그 권장.
+  # git sha, semver 등 불변 태그로 덮어써도 됨.
+  image_tag: "latest"
+
+  # 자가 빌드 이미지를 만들 플랫폼들 (`docker buildx build --platform <list>`).
+  # 한 태그 안의 manifest list 에 모두 들어가므로 노드는 자기 arch 변종을 알아서 pull.
+  build_platforms: ["linux/amd64", "linux/arm64"]
 
   # TODO(init): docker build/push 대상 레지스트리. 클러스터에서 접근 가능해야 함.
-  # 빈 문자열이면 push 를 생략 (build 만).
+  # 빈 문자열이면 안 됨 — multi-arch 이미지는 빌드 시 곧장 레지스트리로 push 됨.
   registry: "registry.example.local/myproject"
 
   # guard-path.sh 훅과 하네스 정적 체크가 공유하는 쓰기 가드.
@@ -47,16 +52,16 @@ conventions:
 
 environments:
   active: dev
-  # TODO(init): 클러스터에 맞춰 domain_suffix, arch, node_selectors 조정.
+  # TODO(init): 클러스터에 맞춰 domain_suffix, node_selectors 조정.
+  # (arch 는 environments 가 아니라 conventions.build_platforms 에서 정함 — 이미지는
+  #  arch-agnostic 이고, env 차이는 도메인/노드/values 에만 둠.)
   dev:
     domain_suffix: dev.example.local
-    arch: amd64                # `docker build --platform linux/<arch>` 에 사용
     node_selectors:
       storage: node-a
       monitoring: node-b
   prod:
     domain_suffix: cluster.local
-    arch: arm64
     node_selectors:
       storage: node-p1
       monitoring: node-p2

--- a/harness/templates/context/conventions.md.tmpl
+++ b/harness/templates/context/conventions.md.tmpl
@@ -17,10 +17,13 @@
   릴리스 이름에 env 를 인코딩하지 않음.
 - `conventions.label_selector` — 모든 워크로드가 반드시 붙여야 하는
   레이블 (하네스가 `kubectl wait` / `kubectl get pods` 에 사용).
-- `conventions.image_tag` — docker 이미지가 push 되는 태그. 서비스
-  하나가 독립 버전을 갖는 경우에만 차트 안에서 따로 override.
-- `environments.<env>.arch` — 타깃 CPU arch. 하네스가
-  `docker build --platform linux/<arch>` 에 주입함.
+- `conventions.image_tag` — docker 이미지가 push 되는 태그. 자가 빌드
+  이미지는 multi-arch manifest list 라 한 태그에 모든 arch 가 들어감 —
+  서비스 하나가 독립 버전을 갖는 경우에만 차트 안에서 따로 override.
+- `conventions.build_platforms` — 자가 빌드 이미지를 만들 플랫폼 목록
+  (`docker buildx build --platform <list>`). 기본 `["linux/amd64",
+  "linux/arm64"]`. 이미지는 arch-agnostic 이고, env 차이는 도메인/노드/
+  values 에만 둠 (그래서 `environments.<env>` 에 `arch` 가 없음).
 
 이 값들을 차트 파일이나 Dockerfile 에 중복 기재하지 말 것. YAML
 에서 읽거나, 하네스가 주입하도록 둘 것.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,17 +27,16 @@ MINIMAL_YAML = dedent(
       write_denied_globs: ["{workspace}/tests/**"]
       registry: "registry.test/myns"
       image_tag: "dev"
+      build_platforms: ["linux/amd64", "linux/arm64"]
 
     environments:
       active: dev
       dev:
         domain_suffix: dev.example.local
-        arch: amd64
         node_selectors:
           storage: node-a
       prod:
         domain_suffix: cluster.local
-        arch: arm64
         node_selectors:
           storage: node-p
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,6 +23,7 @@ def test_resolve_substitutes_service_and_env(cfg):
     assert rs.docker_path == Path("ws/docker/prometheus")
     assert rs.registry == "registry.test/myns"
     assert rs.image_tag == "dev"
+    assert rs.build_platforms == ("linux/amd64", "linux/arm64")
 
 
 def test_resolve_values_files_bind_active_env(cfg):
@@ -33,7 +34,6 @@ def test_resolve_values_files_bind_active_env(cfg):
 def test_env_lookup(cfg):
     dev = cfg.env("dev")
     assert dev.domain_suffix == "dev.example.local"
-    assert dev.arch == "amd64"
     assert dev.node_selectors["storage"] == "node-a"
 
 
@@ -74,7 +74,7 @@ def test_invalid_active_env_raises(tmp_path: Path):
         "conventions: {workspace_dir: ws}\n"
         "environments:\n"
         "  active: staging\n"  # not defined below
-        "  dev: {domain_suffix: d, arch: amd64}\n"
+        "  dev: {domain_suffix: d}\n"
         "checks:\n"
         "  static: {}\n"
         "  runtime:\n"
@@ -95,7 +95,7 @@ def test_defaults_fill_when_fields_missing(tmp_path: Path):
         "conventions: {workspace_dir: ws, registry: r}\n"
         "environments:\n"
         "  active: dev\n"
-        "  dev: {domain_suffix: d, arch: amd64}\n"
+        "  dev: {domain_suffix: d}\n"
         "checks:\n"
         "  static: {}\n"
         "  runtime:\n"
@@ -108,6 +108,7 @@ def test_defaults_fill_when_fields_missing(tmp_path: Path):
     c = load_config(minimal)
     # Defaults from refactor.md §9 kick in
     assert c.conventions.release_name == "{service}"
-    assert c.conventions.image_tag == "dev"
+    assert c.conventions.image_tag == "latest"
+    assert c.conventions.build_platforms == ("linux/amd64", "linux/arm64")
     assert c.checks.runtime.kubectl_wait.initial_wait_seconds == 60
     assert c.checks.runtime.kubectl_wait.terminal_grace_seconds == 240

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -76,12 +76,15 @@ def test_apply_docker_build_push(cfg, docker_dir, stub):
     results = runtime.apply("svc", cfg)
     names = [r.name for r in results]
     assert "docker_build" in names
-    assert "docker_push" in names
+    # buildx --push collapses build+push into one step — no separate docker_push
+    assert "docker_push" not in names
     assert all(r.status == "pass" for r in results)
-    # verify --platform flag was passed
+    # verify it's a multi-arch buildx --push command
     build_cmd = next(cmd for label, cmd in stub.calls if label == "apply/docker_build")
+    assert build_cmd[:3] == ["docker", "buildx", "build"]
     assert "--platform" in build_cmd
-    assert "linux/amd64" in build_cmd
+    assert "linux/amd64,linux/arm64" in build_cmd
+    assert "--push" in build_cmd
 
 
 def test_apply_helm_fresh_install(cfg, helm_chart, stub):
@@ -114,7 +117,7 @@ def test_apply_docker_fail_skips_helm(cfg, tmp_path: Path, monkeypatch, stub):
     results = runtime.apply("svc", cfg)
     names = {r.name: r.status for r in results}
     assert names["docker_build"] == "fail"
-    assert names["docker_push"] == "skip"
+    assert "docker_push" not in names
     assert names.get("helm_install") == "skip"
 
 


### PR DESCRIPTION
## 변경 사항
자가 빌드 이미지({workspace}/docker/<svc>/Dockerfile 있는 서비스)의 빌드 흐름을 단일 arch docker build + docker push에서 multi-arch docker buildx build --push 단일 명령으로 교체. 한 태그(<registry>/<svc>:<tag>)가 manifest list로 모든 arch를 담으므로 arch가 더는 태그 클로버 차원이 아님 → image_tag 기본값을 dev에서 env/arch-중립인 latest로 변경(오버라이드는 유지), 이제 안 쓰이는 environments.<env>.arch 필드 제거.

## 주요 작업 내용
- [x] harness/runtime.py — _docker_apply를 docker buildx build --platform <list> -t <img> --push <ctx> 단일 명령으로; 체크 docker_build 하나로 통합(docker_push 제거); registry 비면 fail; active_environment().arch 사용 제거
- [x] harness/config.py — conventions.build_platforms 추가(기본 ("linux/amd64","linux/arm64")); image_tag 기본값 "dev"→"latest"; Environment에서 arch 제거
- [x] README.md — "사전 준비"에 multi-arch 빌더 셋업 절(buildx 플러그인 + tonistiigi/binfmt + docker buildx create --driver docker-container, 재부팅/Docker Desktop 주의)
- [x] 템플릿 동기화 — config/harness.yaml.example.tmpl, context/conventions.md.tmpl, .claude/skills/docker-author/SKILL.md.tmpl, .claude/skills/cluster-env-inject/SKILL.md.tmpl, AGENTS.md.tmpl
- [x] docs/design.md — apply 흐름·"새 environment 추가" 갱신
- [x] 테스트 — tests/conftest.py(env에서 arch: 제거, build_platforms 추가), tests/test_config.py(build_platforms 기본값·image_tag 기본값 latest·dev.arch 단언 삭제), tests/test_runtime.py(buildx 명령·--push·docker_push 없음 검증)

## 관련 이슈 번호
- Closes #22 

## 테스트 결과
.