### PR TITLE
feat(helm): --post-renderer support via conventions.post_render_script

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -59,6 +59,7 @@ cfg = load_config()                             # @lru_cache
 cfg.resolve("prometheus").release_name          # "prometheus"
 cfg.resolve("prometheus").chart_path            # Path("workspace/helm/prometheus")
 cfg.resolve("prometheus").values_files()        # [Path("values.yaml"), Path("values-dev.yaml")]
+cfg.resolve("prometheus").post_renderer_args()  # ["--post-renderer", "<abs>/post-render.sh"] | []
 cfg.env("dev").domain_suffix                    # environments.dev 에서
 cfg.active_environment()                        # 축약 — env(cfg.active_env)
 cfg.smoke_test_path("svc", "p1")                # Path("workspace/tests/p1/smoke-test-svc.sh")
@@ -69,6 +70,8 @@ cfg.checks.runtime.kubectl_wait.initial_wait_seconds  # int
 여기서 풀리는 치환 토큰: `{service}`, `{active_env}`, `{workspace}`, `{phase}`.
 
 기본값(refactor.md §9): YAML 이 `release_name`, `image_tag`, `kubectl_wait.initial_wait_seconds` 등을 생략하면 기본값이 채워짐. `config.py` 의 `_parse` 참조.
+
+**Post-render hook.** chart 디렉토리에 `conventions.post_render_script`(기본 `post-render.sh`) 이름의 *실행 가능한* 파일이 있으면 모든 helm 렌더 호출(`helm template` ·`upgrade --install` ·`--dry-run=server`)에 `--post-renderer <abs path>` 가 붙음 — 없으면 무시(`Dockerfile` 과 같은 detection-gate). 직접 못 고치는 벤더드 서브차트의 렌더 산출물을 패치하기 위한 탈출구(예: 업스트림 StatefulSet `metadata` 에 Reloader annotation 주입). 보통 `kustomize build` 를 부르는 짧은 래퍼 + `kustomization.yaml`. `helm lint` 는 `--post-renderer` 미지원이라 chart 소스만 봄.
 
 ### `shell.py`
 

--- a/harness/config.py
+++ b/harness/config.py
@@ -60,6 +60,7 @@ class Conventions:
     release_name: str
     label_selector: str
     values_files: tuple[str, ...]
+    post_render_script: str
     write_allowed_globs: tuple[str, ...]
     write_denied_globs: tuple[str, ...]
     registry: str
@@ -128,6 +129,7 @@ class ResolvedService:
     release_name: str
     label_selector: str
     chart_path: Path
+    post_render_script: Path
     docker_path: Path
     registry: str
     image_tag: str
@@ -141,6 +143,20 @@ class ResolvedService:
             Path(pat.format(active_env=self._active_env))
             for pat in self._values_file_patterns
         ]
+
+    def post_renderer_args(self) -> list[str]:
+        """``['--post-renderer', <abs path>]`` if the chart ships an executable
+        post-render script at ``conventions.post_render_script``, else ``[]``.
+
+        Lets a chart patch the rendered manifests of a vendored subchart it
+        can't edit (e.g. inject a Reloader annotation onto an upstream
+        StatefulSet) — see ``helm-chart-author`` skill. Detection-gated like
+        ``Dockerfile``: drop the file in and ``chmod +x`` it; nothing else.
+        """
+        pr = self.post_render_script
+        if pr.is_file() and os.access(pr, os.X_OK):
+            return ["--post-renderer", str(pr.resolve())]
+        return []
 
 
 @dataclass(frozen=True)
@@ -172,12 +188,14 @@ class Config:
             "service": service,
             "active_env": self.active_env,
         }
+        chart_path = Path(c.chart_path.format(**subs))
         return ResolvedService(
             service=service,
             namespace=self.cluster.namespace,
             release_name=c.release_name.format(**subs),
             label_selector=c.label_selector.format(**subs),
-            chart_path=Path(c.chart_path.format(**subs)),
+            chart_path=chart_path,
+            post_render_script=chart_path / c.post_render_script.format(**subs),
             docker_path=Path(c.docker_path.format(**subs)),
             registry=c.registry,
             image_tag=c.image_tag,
@@ -223,6 +241,7 @@ def _parse(raw: dict, source: Path) -> Config:
         release_name=str(conv_raw.get("release_name", "{service}")),
         label_selector=str(conv_raw.get("label_selector", "app.kubernetes.io/name={service}")),
         values_files=tuple(conv_raw.get("values_files") or ["values.yaml", "values-{active_env}.yaml"]),
+        post_render_script=str(conv_raw.get("post_render_script", "post-render.sh")),
         write_allowed_globs=tuple(conv_raw.get("write_allowed_globs") or [
             "{workspace}/helm/**",
             "{workspace}/docker/**",

--- a/harness/runtime.py
+++ b/harness/runtime.py
@@ -149,6 +149,7 @@ def _helm_apply(rs: ResolvedService, cfg: Config) -> list[CheckResult]:
         "-n", rs.namespace,
         "--create-namespace",
         "--timeout", "180s",
+        *rs.post_renderer_args(),
         *_values_args(rs),
     ]
     up = shell.run(upgrade_cmd, label="apply/helm_install")
@@ -205,6 +206,7 @@ def _chart_workload_classes(rs: ResolvedService, cfg: Config) -> tuple[bool, boo
     cmd = [
         "helm", "template", rs.release_name, str(rs.chart_path),
         "-n", rs.namespace,
+        *rs.post_renderer_args(),
         *_values_args(rs),
     ]
     r = shell.run(cmd, label="verify-runtime/helm_template", log_stdout=False)

--- a/harness/static.py
+++ b/harness/static.py
@@ -114,6 +114,7 @@ def check_kubeconform(rs: ResolvedService, cfg: Config) -> CheckResult:
     helm_cmd = [
         "helm", "template", rs.release_name, str(rs.chart_path),
         "-n", rs.namespace,
+        *rs.post_renderer_args(),
         *_values_args(rs),
     ]
     kcf_cmd = ["kubeconform", "-strict", "-summary", "-ignore-missing-schemas", "-"]
@@ -154,6 +155,7 @@ def check_helm_dry_run_server(rs: ResolvedService, cfg: Config) -> CheckResult:
         "helm", "upgrade", "--install", rs.release_name, str(rs.chart_path),
         "-n", rs.namespace,
         "--dry-run=server",
+        *rs.post_renderer_args(),
         *_values_args(rs),
     ]
     r = shell.run(cmd, label="static/helm_dry_run_server")

--- a/harness/templates/.claude/skills/helm-chart-author/SKILL.md.tmpl
+++ b/harness/templates/.claude/skills/helm-chart-author/SKILL.md.tmpl
@@ -99,6 +99,53 @@ Before writing `image.repository`, check whether
 If you are unsure which mode a service uses, check for the presence
 of `{{workspace_dir}}/docker/<service>/Dockerfile` before editing.
 
+## Patching a vendored subchart (post-render)
+
+When this chart pulls an upstream chart as a `dependencies:` entry and
+that subchart's rendered manifest needs a tweak it exposes no value
+for (the classic case: a Reloader annotation —
+`reloader.stakater.com/auto` or `configmap.reloader.stakater.com/reload`
+— on the upstream `Deployment`/`StatefulSet` `metadata.annotations`,
+which Reloader reads from the workload object, not the pod template),
+**do not hand-edit the vendored `charts/*.tgz`**. Drop a post-renderer
+into the chart directory:
+
+```
+{{workspace_dir}}/helm/<service>/
+├── Chart.yaml
+├── post-render.sh          # executable — `chmod +x`
+└── kustomization.yaml
+```
+
+```sh
+# post-render.sh
+#!/bin/sh
+set -e
+d=$(mktemp -d); trap 'rm -rf "$d"' EXIT
+cat > "$d/all.yaml"
+cp "$(dirname "$0")/kustomization.yaml" "$d/"
+kubectl kustomize "$d"
+```
+
+```yaml
+# kustomization.yaml
+resources: [all.yaml]
+patches:
+  - target: { group: apps, version: v1, kind: StatefulSet, name: <upstream-name> }
+    patch: |
+      - op: add
+        path: /metadata/annotations/configmap.reloader.stakater.com~1reload
+        value: <configmap-name>
+```
+
+The harness auto-detects an executable file named per
+`conventions.post_render_script` (default `post-render.sh`) and adds
+`--post-renderer <abs path>` to `helm template`, `helm upgrade --install`,
+and `helm upgrade --dry-run=server` — so kubeconform / dry-run validate
+the patched output too. Nothing to wire up; if the file isn't there (or
+isn't executable) it's a no-op. Prefer real chart values whenever the
+subchart offers them — reach for this only when it genuinely doesn't.
+
 ## Kubeconform / yamllint cleanliness
 
 - Keep `apiVersion`, `kind`, `metadata` at the top of every manifest.
@@ -113,9 +160,10 @@ of `{{workspace_dir}}/docker/<service>/Dockerfile` before editing.
 - `yamllint` (excludes `templates/`)
 - `helm lint` with all `values.yaml` + `values-<active_env>.yaml` passed via `-f`
 - `helm template … | kubeconform -strict -ignore-missing-schemas`
+  (+ `--post-renderer` if a `post-render.sh` is present — see above)
 - `trivy config` on the chart directory
 - `gitleaks detect` on the chart directory
-- `helm upgrade --install --dry-run=server` (needs cluster)
+- `helm upgrade --install --dry-run=server` (needs cluster; also `--post-renderer` aware)
 
 The PostToolUse hook runs only `yamllint` on the single touched file
 for fast feedback; the full suite runs at `/deploy` time.

--- a/harness/templates/config/harness.yaml.example.tmpl
+++ b/harness/templates/config/harness.yaml.example.tmpl
@@ -28,6 +28,14 @@ conventions:
   # -f 로 이 순서대로 넘기는 values 파일. {active_env} 는 resolve() 시점 바인딩.
   values_files: ["values.yaml", "values-{active_env}.yaml"]
 
+  # chart 디렉토리 기준 post-render 스크립트 경로 (helm `--post-renderer`).
+  # 이 이름의 *실행 가능한* 파일이 chart 디렉토리에 있으면 helm template/upgrade/
+  # dry-run 에 자동으로 `--post-renderer <abs path>` 가 붙음 — 없으면 무시됨.
+  # 용도: 직접 못 고치는 벤더드 서브차트의 렌더 산출물 패치 (예: 업스트림
+  # StatefulSet metadata 에 Reloader annotation 주입). 보통 kustomize 래퍼.
+  # 빈 문자열이면 비활성.
+  post_render_script: "post-render.sh"
+
   # docker 이미지 태그. `<registry>/<service>:<tag>` 로 기록됨. 자가 빌드 이미지는
   # multi-arch manifest list 라 arch 별로 태그가 갈리지 않음 — 중립 태그 권장.
   # git sha, semver 등 불변 태그로 덮어써도 됨.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -20,10 +21,51 @@ def test_resolve_substitutes_service_and_env(cfg):
     assert rs.release_name == "prometheus"
     assert rs.label_selector == "app.kubernetes.io/name=prometheus"
     assert rs.chart_path == Path("ws/helm/prometheus")
+    assert rs.post_render_script == Path("ws/helm/prometheus/post-render.sh")
     assert rs.docker_path == Path("ws/docker/prometheus")
     assert rs.registry == "registry.test/myns"
     assert rs.image_tag == "dev"
     assert rs.build_platforms == ("linux/amd64", "linux/arm64")
+
+
+def test_post_renderer_args_absent_when_no_script(cfg, tmp_path: Path):
+    chart = tmp_path / "ws" / "helm" / "prometheus"
+    chart.mkdir(parents=True)
+    assert cfg.resolve("prometheus").post_renderer_args() == []
+
+
+def test_post_renderer_args_present_when_executable_script(cfg, tmp_path: Path):
+    chart = tmp_path / "ws" / "helm" / "prometheus"
+    chart.mkdir(parents=True)
+    script = chart / "post-render.sh"
+    script.write_text("#!/bin/sh\ncat\n")
+    # not executable yet → ignored
+    assert cfg.resolve("prometheus").post_renderer_args() == []
+    script.chmod(0o755)
+    args = cfg.resolve("prometheus").post_renderer_args()
+    assert args[0] == "--post-renderer"
+    assert Path(args[1]) == script.resolve()
+    assert os.path.isabs(args[1])
+
+
+def test_post_render_script_disabled_by_empty_string(tmp_path: Path):
+    bad = tmp_path / "h.yaml"
+    bad.write_text(
+        "cluster: {namespace: x}\n"
+        "conventions: {workspace_dir: ws, registry: r, post_render_script: ''}\n"
+        "environments:\n  active: dev\n  dev: {domain_suffix: d}\n"
+        "checks:\n  static: {}\n  runtime:\n    kubectl_wait: {}\n"
+        "logging: {dir: logs, tail_chars: 100, retention_days: 7}\n"
+        "orchestration: {max_runtime_retries: 3}\n",
+        encoding="utf-8",
+    )
+    load_config.cache_clear()
+    c = load_config(bad)
+    rs = c.resolve("prometheus")
+    # chart_path / "" == chart_path (a dir) → never a file → no --post-renderer
+    assert rs.post_render_script == Path("ws/helm/prometheus")
+    (tmp_path / "ws" / "helm" / "prometheus").mkdir(parents=True)
+    assert rs.post_renderer_args() == []
 
 
 def test_resolve_values_files_bind_active_env(cfg):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -105,6 +105,39 @@ def test_apply_helm_uninstall_when_release_exists(cfg, helm_chart, stub):
     assert "apply/helm_install" in labels
 
 
+def _add_post_render_script(chart: Path) -> Path:
+    script = chart / "post-render.sh"
+    script.write_text("#!/bin/sh\ncat\n")
+    script.chmod(0o755)
+    return script
+
+
+def test_apply_helm_install_adds_post_renderer_when_script_present(cfg, helm_chart, stub):
+    script = _add_post_render_script(helm_chart)
+    stub.set("apply/helm_status", exit_code=1)
+    runtime.apply("svc", cfg)
+    install_cmd = next(cmd for label, cmd in stub.calls if label == "apply/helm_install")
+    assert "--post-renderer" in install_cmd
+    assert install_cmd[install_cmd.index("--post-renderer") + 1] == str(script.resolve())
+    # must come before the -f value files (helm flag-order tolerant, but keep it tidy)
+    assert install_cmd.index("--post-renderer") < install_cmd.index("-f")
+
+
+def test_apply_helm_install_no_post_renderer_when_script_absent(cfg, helm_chart, stub):
+    stub.set("apply/helm_status", exit_code=1)
+    runtime.apply("svc", cfg)
+    install_cmd = next(cmd for label, cmd in stub.calls if label == "apply/helm_install")
+    assert "--post-renderer" not in install_cmd
+
+
+def test_apply_helm_install_ignores_non_executable_post_render_script(cfg, helm_chart, stub):
+    (helm_chart / "post-render.sh").write_text("#!/bin/sh\ncat\n")  # no chmod +x
+    stub.set("apply/helm_status", exit_code=1)
+    runtime.apply("svc", cfg)
+    install_cmd = next(cmd for label, cmd in stub.calls if label == "apply/helm_install")
+    assert "--post-renderer" not in install_cmd
+
+
 def test_apply_docker_fail_skips_helm(cfg, tmp_path: Path, monkeypatch, stub):
     # set up both helm and docker
     monkeypatch.chdir(tmp_path)
@@ -203,6 +236,16 @@ def test_verify_runtime_kubectl_wait_pass(cfg, helm_chart, stub):
     results = runtime.verify_runtime("svc", cfg)
     kw = next(r for r in results if r.name == "kubectl_wait")
     assert kw.status == "pass"
+
+
+def test_verify_runtime_helm_template_uses_post_renderer(cfg, helm_chart, stub):
+    script = _add_post_render_script(helm_chart)
+    stub.set("verify-runtime/helm_template", stdout=_DEPLOY_YAML)
+    stub.set("verify-runtime/kubectl_wait", exit_code=0)
+    runtime.verify_runtime("svc", cfg)
+    tmpl_cmd = next(cmd for label, cmd in stub.calls if label == "verify-runtime/helm_template")
+    assert "--post-renderer" in tmpl_cmd
+    assert tmpl_cmd[tmpl_cmd.index("--post-renderer") + 1] == str(script.resolve())
 
 
 def test_verify_runtime_helm_template_failure_waits_conservatively(cfg, helm_chart, stub):

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -156,3 +156,21 @@ def test_values_files_are_passed_to_helm_lint(cfg, helm_chart, stub):
     joined = " ".join(helm_lint_calls[0])
     assert "values.yaml" in joined
     assert "values-dev.yaml" in joined
+
+
+def test_kubeconform_uses_post_renderer_when_script_present(cfg, helm_chart, stub):
+    script = helm_chart / "post-render.sh"
+    script.write_text("#!/bin/sh\ncat\n")
+    script.chmod(0o755)
+    static.run_static("svc", cfg)
+    tmpl_calls = [c for c in stub.calls if c and c[:2] == ["helm", "template"]]
+    assert tmpl_calls
+    assert "--post-renderer" in tmpl_calls[0]
+    assert tmpl_calls[0][tmpl_calls[0].index("--post-renderer") + 1] == str(script.resolve())
+
+
+def test_kubeconform_no_post_renderer_when_script_absent(cfg, helm_chart, stub):
+    static.run_static("svc", cfg)
+    tmpl_calls = [c for c in stub.calls if c and c[:2] == ["helm", "template"]]
+    assert tmpl_calls
+    assert "--post-renderer" not in tmpl_calls[0]


### PR DESCRIPTION
## 변경 사항
하네스의 helm 호출에 `--post-renderer` 지원 추가. chart 디렉토리에 `conventions.post_render_script`(기본 `post-render.sh`) 이름의 *실행 가능한* 파일이 있으면 `helm template` · `helm upgrade --install` · `--dry-run=server` 에 자동으로 `--post-renderer <abs path>` 가 붙음 (`Dockerfile` 과 같은 detection-gate; 파일 없거나 `+x` 아니면 no-op). 직접 못 고치는 벤더 서브차트의 렌더 산출물을 패치하기 위한 탈출구 — 동기는 step-ca `step-certificates` 차트의 StatefulSet 에 Reloader annotation 주입.

## 주요 작업 내용
- [x] `config.py`: `conventions.post_render_script` 컨벤션(+기본값) / `ResolvedService.post_render_script` / `ResolvedService.post_renderer_args()`
- [x] `runtime.py`: `helm upgrade --install` 와 verify_runtime 의 `helm template`에 `post_renderer_args()` 주입
- [x] `static.py`: `kubeconform`(helm template) 와 `helm_dry_run_server` 에 주입(`helm lint` 은 `--post-renderer` 미지원이라 제외)
- [x] 문서/템플릿: `harness.yaml.example`, `helm-chart-author` 스킬(kustomize 래퍼 패턴 + Reloader 케이스), `docs/design.md`
- [x] 테스트: `test_config.py`(+3) / `test_runtime.py`(+4) / `test_static.py`(+2) — 스크립트 존재 / 부재 / 비실행 케이스

## 관련 이슈 번호
- Closes #24

## 테스트 결과
- `pytest -q` → 71 passed
- `ruff check` (변경 파일) clean, `mypy` 신규 오류 없음 (기존 PyYAML stub 경고만)
- 호환성: 기존 차트는 `post-render.sh` 미존재 시 동작 변화 0